### PR TITLE
use environment for git config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "simple-git"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "compact_str",
  "derive_destructure2",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 use std::{fmt, mem, num::NonZeroU32, path::Path, str::FromStr, sync::atomic::AtomicBool};
 
-use gix::{clone, create, open, remote, Url};
+use gix::{
+    clone, create,
+    open::{self, Permissions},
+    remote, Url,
+};
 use tracing::debug;
 
 mod progress_tracing;
@@ -47,7 +51,7 @@ impl Repository {
                 destination_must_be_empty: true,
                 ..Default::default()
             },
-            open::Options::isolated(),
+            open::Options::default().permissions(Permissions::all()),
         )?
         .with_shallow(remote::fetch::Shallow::DepthAtRemote(
             NonZeroU32::new(1).unwrap(),


### PR DESCRIPTION
resolves #24 
currently it will not use the user's git configuration, since it is running in isolated mode (will only look at the current repository for a git config)