### PR TITLE
Add new feature git-max-perf-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,5 @@ features = [
 rustls = ["gix/blocking-http-transport-reqwest-rust-tls"]
 native-tls = ["gix/blocking-http-transport-reqwest-native-tls"]
 
+git-max-perf-safe = ["gix/max-performance-safe"]
 git-max-perf = ["gix/max-performance"]


### PR DESCRIPTION
For max-perf without pulling in fast-sha1 and libz(-ng), given that sha1 now use rust intrinsics and zlib-rs is the pure rust implementation that are on par with libz-ng regarding performance.